### PR TITLE
Get (kinda) consistent score on GRASTAAutoPricePipeline

### DIFF
--- a/spider/pipelines/GRASTAAutoPricePipeline.py
+++ b/spider/pipelines/GRASTAAutoPricePipeline.py
@@ -87,6 +87,7 @@ class GRASTAAutoPricePipeline(BasePipeline):
             argument_type = ArgumentType.CONTAINER,
             data_reference = 'steps.5.produce' #inputs here are the outputs from step 5
         )
+        step_6.add_hyperparameter(name='constant_step', argument_type=ArgumentType.VALUE, data=0.1)
         step_6.add_output('produce')
         pipeline.add_step(step_6)
         

--- a/spider/unsupervised_learning/grasta/grasta.py
+++ b/spider/unsupervised_learning/grasta/grasta.py
@@ -443,15 +443,7 @@ class GRASTA(unsupervised_learning.UnsupervisedLearnerPrimitiveBase[Inputs, Outp
         xOmega = x[xIdx]
         Uomega = Uhat[xIdx, :]
 
-        #logger.warn(str(Uomega))
-        #logger.warn(str(xOmega))
-        #logger.warn(str(vars(self._admm_OPTS)))
         w_hat, s_hat, y_hat, h = admm(Uomega, xOmega, self._admm_OPTS)
-        #logger.warn(str(w_hat))
-        #logger.warn(str(s_hat))
-        #logger.warn(str(y_hat))
-        logger.warn(str(h))  # DIFFERENT
-        assert False
 
         gamma1 = y_hat + (xOmega - Uomega @ w_hat - s_hat)
         gamma2 = Uomega.T @ gamma1
@@ -466,6 +458,8 @@ class GRASTA(unsupervised_learning.UnsupervisedLearnerPrimitiveBase[Inputs, Outp
 
         t, STATUS_new, admm_OPTS_new = calculate_mla_step(self._grastaSTATUS, self._grastaOPTIONS, self._admm_OPTS,
                                                           gamma, w_hat, sG)
+        t = 0.1
+        logger.warn(str(t))
 
         step = np.multiply.outer([((np.cos(t) - 1) * (Uhat @ w_hat) / w_norm) + (np.sin(t) * gamma / gamma_norm)],
                                  (w_hat / w_norm))

--- a/spider/unsupervised_learning/grasta/grasta.py
+++ b/spider/unsupervised_learning/grasta/grasta.py
@@ -443,7 +443,15 @@ class GRASTA(unsupervised_learning.UnsupervisedLearnerPrimitiveBase[Inputs, Outp
         xOmega = x[xIdx]
         Uomega = Uhat[xIdx, :]
 
+        #logger.warn(str(Uomega))
+        #logger.warn(str(xOmega))
+        #logger.warn(str(vars(self._admm_OPTS)))
         w_hat, s_hat, y_hat, h = admm(Uomega, xOmega, self._admm_OPTS)
+        #logger.warn(str(w_hat))
+        #logger.warn(str(s_hat))
+        #logger.warn(str(y_hat))
+        logger.warn(str(h))  # DIFFERENT
+        assert False
 
         gamma1 = y_hat + (xOmega - Uomega @ w_hat - s_hat)
         gamma2 = Uomega.T @ gamma1

--- a/spider/unsupervised_learning/grasta/grasta.py
+++ b/spider/unsupervised_learning/grasta/grasta.py
@@ -10,8 +10,6 @@ __all__ = ('GRASTA',)
 Inputs = container.ndarray
 Outputs = container.ndarray
 
-import logging
-logger = logging.getLogger(__name__)
 
 class GRASTAHyperparams(hyperparams.Hyperparams):
     # dim = hyperparams.Bounded[int](lower=1,
@@ -285,7 +283,7 @@ class GRASTA(unsupervised_learning.UnsupervisedLearnerPrimitiveBase[Inputs, Outp
         Lhat = np.zeros(_X.shape)
         for i in range(0, numVectors):
             _x = _X[:, i]
-            U, w, _, _, _ = self._grasta_stream(Uhat, _x)
+            U, w, s, STATUS_new, admm_OPTS = self._grasta_stream(Uhat, _x)
             Lhat[:, i] = U @ w
 
         return base.CallResult(container.ndarray(Lhat.T, generate_metadata=True))

--- a/spider/unsupervised_learning/grasta/grasta.py
+++ b/spider/unsupervised_learning/grasta/grasta.py
@@ -390,43 +390,42 @@ class GRASTA(unsupervised_learning.UnsupervisedLearnerPrimitiveBase[Inputs, Outp
 
             if grastaOPTIONS.constant_step > 0:
                 step = grastaOPTIONS.constant_step
-                MAX_ITER = ITER_MAX
             else:
                 step = step_scale * level_factor ** (-level) * sG / (1 + mu)
 
                 if step >= np.pi / 3:
                     step = np.pi / 3
 
-                bShrUpd = 0
+            bShrUpd = 0
 
-                if mu <= MIN_MU:
-                    if level > 1:
-                        bShrUpd = 1
-                        level = level - 1
+            if mu <= MIN_MU:
+                if level > 1:
+                    bShrUpd = 1
+                    level = level - 1
 
-                    mu = DEFAULT_MU_LOW
+                mu = DEFAULT_MU_LOW
 
-                elif mu > MAX_MU:
-                    if level < MAX_LEVEL:
-                        bShrUpd = 1
-                        level = level + 1
-                        mu = DEFAULT_MU_HIGH
-                    else:
-                        mu = MAX_MU
+            elif mu > MAX_MU:
+                if level < MAX_LEVEL:
+                    bShrUpd = 1
+                    level = level + 1
+                    mu = DEFAULT_MU_HIGH
+                else:
+                    mu = MAX_MU
 
-                if bShrUpd:
-                    if level >= 0 and level < 4:
-                        MAX_ITER = grastaOPTIONS.admm_min_itr
-                    elif level >= 4 and level < 7:
-                        MAX_ITER = min(MIN_ITER * 2, ITER_MAX)
-                    elif level >= 7 and level < 10:
-                        MAX_ITER = min(MIN_ITER * 4, ITER_MAX)
-                    elif level >= 10 and level < 14:
-                        MAX_ITER = min(MIN_ITER * 8, ITER_MAX)
-                    else:
-                        MAX_ITER = ITER_MAX
+            if bShrUpd:
+                if level >= 0 and level < 4:
+                    MAX_ITER = grastaOPTIONS.admm_min_itr
+                elif level >= 4 and level < 7:
+                    MAX_ITER = min(MIN_ITER * 2, ITER_MAX)
+                elif level >= 7 and level < 10:
+                    MAX_ITER = min(MIN_ITER * 4, ITER_MAX)
+                elif level >= 10 and level < 14:
+                    MAX_ITER = min(MIN_ITER * 8, ITER_MAX)
                 else:
                     MAX_ITER = ITER_MAX
+            else:
+                MAX_ITER = ITER_MAX
 
             STATUS_new = _STATUS(mu, w, gamma, level, step_scale)
             ADMM_OPTS_new = _OPTS(MAX_ITER, admm_OPTS.rho, admm_OPTS.tol)
@@ -458,8 +457,6 @@ class GRASTA(unsupervised_learning.UnsupervisedLearnerPrimitiveBase[Inputs, Outp
 
         t, STATUS_new, admm_OPTS_new = calculate_mla_step(self._grastaSTATUS, self._grastaOPTIONS, self._admm_OPTS,
                                                           gamma, w_hat, sG)
-        t = 0.1
-        logger.warn(str(t))
 
         step = np.multiply.outer([((np.cos(t) - 1) * (Uhat @ w_hat) / w_norm) + (np.sin(t) * gamma / gamma_norm)],
                                  (w_hat / w_norm))

--- a/spider/unsupervised_learning/grasta/grasta.py
+++ b/spider/unsupervised_learning/grasta/grasta.py
@@ -10,6 +10,8 @@ __all__ = ('GRASTA',)
 Inputs = container.ndarray
 Outputs = container.ndarray
 
+import logging
+logger = logging.getLogger(__name__)
 
 class GRASTAHyperparams(hyperparams.Hyperparams):
     # dim = hyperparams.Bounded[int](lower=1,
@@ -283,7 +285,7 @@ class GRASTA(unsupervised_learning.UnsupervisedLearnerPrimitiveBase[Inputs, Outp
         Lhat = np.zeros(_X.shape)
         for i in range(0, numVectors):
             _x = _X[:, i]
-            U, w, s, STATUS_new, admm_OPTS = self._grasta_stream(Uhat, _x)
+            U, w, _, _, _ = self._grasta_stream(Uhat, _x)
             Lhat[:, i] = U @ w
 
         return base.CallResult(container.ndarray(Lhat.T, generate_metadata=True))


### PR DESCRIPTION
This addresses issue #30, where GRASTAAutoPricePipeline scores are different across hosts. The fix involves two changes:

* `constant_step` is provided as a hyperparameter in the pipeline
* In `calculate_mla_step()`, MAX_ITER is *always* computed dynamically regardless of whether `constant_step` is provided as a hyperparameter.

Now GRASTAAutoPricePipeline gives a score of about 7197392 across hosts. Also, GRASTAAutoMPGPipeline behaves the same as before.

@kgilman Can you check the changes to `calculate_mla_step()` and confirm that this is acceptable?