### PR TITLE
Use D3M internal datasets

### DIFF
--- a/michigan-private/dataset_repo_info.json
+++ b/michigan-private/dataset_repo_info.json
@@ -1,4 +1,4 @@
 {
-    "commit_hash": "073904169f747bbbd0b64d93498484aadfcfd459",
+    "commit_hash": "8bff2419664627f540ce08b8e3db023e9f4d65b3",
     "origin_url": "git@gitlab.datadrivendiscovery.org:d3m/datasets.git"
 }

--- a/michigan-private/dataset_repo_info.json
+++ b/michigan-private/dataset_repo_info.json
@@ -1,0 +1,4 @@
+{
+    "commit_hash": "073904169f747bbbd0b64d93498484aadfcfd459",
+    "origin_url": "git@gitlab.datadrivendiscovery.org:d3m/datasets.git"
+}

--- a/michigan-private/docker_reset.sh
+++ b/michigan-private/docker_reset.sh
@@ -23,7 +23,7 @@ docker run -d \
   -it \
   --name "$DOCKER_CONTAINER_NAME" \
   --mount type=bind,source="$(pwd)",target=/spider \
-  --mount type=bind,source=/z/mid/D3M/datasets_public,target=/datasets \
+  --mount type=bind,source=/z/mid/D3M/datasets,target=/datasets \
   --mount type=bind,source=/z/mid/D3M/volumes,target=/volumes \
   --env "HOST_USER=$(id -u)" \
   --env "HOST_GROUP=$(id -g)" \

--- a/spider/pipelines/EKSSOneHundredPlantsMarginPipeline.py
+++ b/spider/pipelines/EKSSOneHundredPlantsMarginPipeline.py
@@ -23,7 +23,6 @@ class EKSSOneHundredPlantsMarginPipeline(BasePipeline):
         
         #choose one or more seed datasets on which this pipeline can operate
         self.dataset = '1491_one_hundred_plants_margin'
-        self.meta_info = self.genmeta(self.dataset)
 
     def get_primitive_entry_point(self):
         return 'd3m.primitives.clustering.ekss.Umich'

--- a/spider/pipelines/GODECHandgeometryPipeline.py
+++ b/spider/pipelines/GODECHandgeometryPipeline.py
@@ -20,7 +20,6 @@ class GODECHandgeometryPipeline(BasePipeline):
         super().__init__()
 
         self.dataset = '22_handgeometry'
-        self.meta_info = self.genmeta(self.dataset)
 
     def get_primitive_entry_point(self):
         return 'd3m.primitives.data_compression.go_dec.Umich'

--- a/spider/pipelines/GRASTAAutoMPGPipeline.py
+++ b/spider/pipelines/GRASTAAutoMPGPipeline.py
@@ -22,8 +22,7 @@ class GRASTAAutoMPGPipeline(BasePipeline):
         super().__init__()
         
         #specify one seed dataset on which this pipeline can operate
-        self.dataset = '196_autoMpg'
-        self.meta_info = self.genmeta(self.dataset)
+        self.dataset = '196_autoMpg_MIN_METADATA'
 
     def get_primitive_entry_point(self):
         return 'd3m.primitives.data_compression.grasta.Umich'

--- a/spider/pipelines/GRASTAAutoMPGPipeline.py
+++ b/spider/pipelines/GRASTAAutoMPGPipeline.py
@@ -9,6 +9,7 @@ from d3m.primitives.data_transformation.dataset_to_dataframe import Common as Da
 from d3m.primitives.data_transformation.column_parser import Common as ColumnParserPrimitive
 from d3m.primitives.data_transformation.construct_predictions import Common as ConstructPredictionsPrimitive
 from d3m.primitives.data_transformation.extract_columns_by_semantic_types import Common as ExtractColumnsBySemanticTypesPrimitive
+from d3m.primitives.schema_discovery.profiler import Common as SimpleProfilerPrimitive
 from sklearn_wrap.SKLinearSVR import SKLinearSVR
 from sklearn_wrap.SKImputer import SKImputer
 
@@ -39,68 +40,74 @@ class GRASTAAutoMPGPipeline(BasePipeline):
         step_0.add_output('produce')
         pipeline.add_step(step_0)
 
-        # ColumnParser
-        step_1 = meta_pipeline.PrimitiveStep(primitive_description=ColumnParserPrimitive.metadata.query())
+        # Profiler to infer semantic types
+        step_1 = meta_pipeline.PrimitiveStep(primitive_description=SimpleProfilerPrimitive.metadata.query())
         step_1.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference='steps.0.produce')
         step_1.add_output('produce')
         pipeline.add_step(step_1)
 
-        # Extract Attributes
-        step_2 = meta_pipeline.PrimitiveStep(primitive_description = ExtractColumnsBySemanticTypesPrimitive.metadata.query())
+        # ColumnParser
+        step_2 = meta_pipeline.PrimitiveStep(primitive_description=ColumnParserPrimitive.metadata.query())
         step_2.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference='steps.1.produce')
         step_2.add_output('produce')
-        step_2.add_hyperparameter(name='semantic_types', argument_type=ArgumentType.VALUE, data=['https://metadata.datadrivendiscovery.org/types/Attribute'] )
-        step_2.add_hyperparameter(name='exclude_columns', argument_type=ArgumentType.VALUE, data=[0, 1, 6, 7])
         pipeline.add_step(step_2)
 
-        # Impute missing data and nans
-        step_3 = meta_pipeline.PrimitiveStep(primitive_description = SKImputer.metadata.query())
+        # Extract Attributes
+        step_3 = meta_pipeline.PrimitiveStep(primitive_description = ExtractColumnsBySemanticTypesPrimitive.metadata.query())
         step_3.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference='steps.2.produce')
         step_3.add_output('produce')
-        step_3.add_hyperparameter(name='use_semantic_types', argument_type=ArgumentType.VALUE, data=True)
-        step_3.add_hyperparameter(name='return_result', argument_type=ArgumentType.VALUE, data='replace')
+        step_3.add_hyperparameter(name='semantic_types', argument_type=ArgumentType.VALUE, data=['https://metadata.datadrivendiscovery.org/types/Attribute'] )
+        step_3.add_hyperparameter(name='exclude_columns', argument_type=ArgumentType.VALUE, data=[0, 1, 6, 7])
         pipeline.add_step(step_3)
 
-        # Extract Targets
-        step_4 = meta_pipeline.PrimitiveStep(primitive_description = ExtractColumnsBySemanticTypesPrimitive.metadata.query())
-        step_4.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference='steps.1.produce')
+        # Impute missing data and nans
+        step_4 = meta_pipeline.PrimitiveStep(primitive_description = SKImputer.metadata.query())
+        step_4.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference='steps.3.produce')
         step_4.add_output('produce')
-        step_4.add_hyperparameter(name='semantic_types', argument_type=ArgumentType.VALUE, data=['https://metadata.datadrivendiscovery.org/types/TrueTarget'] )
+        step_4.add_hyperparameter(name='use_semantic_types', argument_type=ArgumentType.VALUE, data=True)
+        step_4.add_hyperparameter(name='return_result', argument_type=ArgumentType.VALUE, data='replace')
         pipeline.add_step(step_4)
 
-        # Transform attributes dataframe into an ndarray
-        step_5 = meta_pipeline.PrimitiveStep(primitive_description=DataFrameToNDArrayPrimitive.metadata.query())
-        step_5.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference='steps.3.produce')
+        # Extract Targets
+        step_5 = meta_pipeline.PrimitiveStep(primitive_description = ExtractColumnsBySemanticTypesPrimitive.metadata.query())
+        step_5.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference='steps.2.produce')
         step_5.add_output('produce')
+        step_5.add_hyperparameter(name='semantic_types', argument_type=ArgumentType.VALUE, data=['https://metadata.datadrivendiscovery.org/types/TrueTarget'] )
         pipeline.add_step(step_5)
 
-        # Run GRASTA
-        step_6 = meta_pipeline.PrimitiveStep(primitive_description = GRASTA.metadata.query())
-        step_6.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference='steps.5.produce')
+        # Transform attributes dataframe into an ndarray
+        step_6 = meta_pipeline.PrimitiveStep(primitive_description=DataFrameToNDArrayPrimitive.metadata.query())
+        step_6.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference='steps.4.produce')
         step_6.add_output('produce')
         pipeline.add_step(step_6)
-        
-        # Convert numpy-formatted attribute data to a dataframe
-        step_7 = meta_pipeline.PrimitiveStep(primitive_description=NDArrayToDataFramePrimitive.metadata.query())
+
+        # Run GRASTA
+        step_7 = meta_pipeline.PrimitiveStep(primitive_description = GRASTA.metadata.query())
         step_7.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference='steps.6.produce')
         step_7.add_output('produce')
         pipeline.add_step(step_7)
-
-        # Linear Regression on low-rank data (inputs and outputs for sklearns are both dataframes)
-        step_8 = meta_pipeline.PrimitiveStep(primitive_description=SKLinearSVR.metadata.query())
+        
+        # Convert numpy-formatted attribute data to a dataframe
+        step_8 = meta_pipeline.PrimitiveStep(primitive_description=NDArrayToDataFramePrimitive.metadata.query())
         step_8.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference='steps.7.produce')
-        step_8.add_argument(name='outputs', argument_type=ArgumentType.CONTAINER, data_reference='steps.4.produce')
         step_8.add_output('produce')
         pipeline.add_step(step_8)
 
-        # Finally generate a properly-formatted output dataframe from the prediction outputs using the input dataframe as a reference
-        step_9 = meta_pipeline.PrimitiveStep(primitive_description=ConstructPredictionsPrimitive.metadata.query())
+        # Linear Regression on low-rank data (inputs and outputs for sklearns are both dataframes)
+        step_9 = meta_pipeline.PrimitiveStep(primitive_description=SKLinearSVR.metadata.query())
         step_9.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference='steps.8.produce')
-        step_9.add_argument(name='reference', argument_type=ArgumentType.CONTAINER, data_reference='steps.0.produce')
+        step_9.add_argument(name='outputs', argument_type=ArgumentType.CONTAINER, data_reference='steps.5.produce')
         step_9.add_output('produce')
         pipeline.add_step(step_9)
 
+        # Finally generate a properly-formatted output dataframe from the prediction outputs using the input dataframe as a reference
+        step_10 = meta_pipeline.PrimitiveStep(primitive_description=ConstructPredictionsPrimitive.metadata.query())
+        step_10.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference='steps.9.produce')
+        step_10.add_argument(name='reference', argument_type=ArgumentType.CONTAINER, data_reference='steps.0.produce')
+        step_10.add_output('produce')
+        pipeline.add_step(step_10)
+
         # Adding output step to the pipeline
-        pipeline.add_output(name='output', data_reference='steps.9.produce')
+        pipeline.add_output(name='output', data_reference='steps.10.produce')
 
         return pipeline

--- a/spider/pipelines/GRASTAAutoMPGPipeline.py
+++ b/spider/pipelines/GRASTAAutoMPGPipeline.py
@@ -5,7 +5,6 @@ from spider.pipelines.base import BasePipeline
 from spider.unsupervised_learning.grasta import GRASTA
 from d3m.primitives.data_transformation.dataframe_to_ndarray import Common as DataFrameToNDArrayPrimitive
 from d3m.primitives.data_transformation.ndarray_to_dataframe import Common as NDArrayToDataFramePrimitive
-from d3m.primitives.data_transformation.construct_predictions import Common as ConstructPredictionsPrimitive
 from d3m.primitives.data_transformation.dataset_to_dataframe import Common as DatasetToDataFramePrimitive
 from d3m.primitives.data_transformation.column_parser import Common as ColumnParserPrimitive
 from d3m.primitives.data_transformation.construct_predictions import Common as ConstructPredictionsPrimitive
@@ -34,27 +33,27 @@ class GRASTAAutoMPGPipeline(BasePipeline):
         #define inputs.  This will be read in automatically as a Dataset object.
         pipeline.add_input(name = 'inputs')
 
-        # Step 0: DatasetToDataFrame
+        # DatasetToDataFrame
         step_0 = meta_pipeline.PrimitiveStep(primitive_description = DatasetToDataFramePrimitive.metadata.query())
         step_0.add_argument(name='inputs', argument_type = ArgumentType.CONTAINER, data_reference='inputs.0')
         step_0.add_output('produce')
         pipeline.add_step(step_0)
 
-        # Step 1: ColumnParser
+        # ColumnParser
         step_1 = meta_pipeline.PrimitiveStep(primitive_description=ColumnParserPrimitive.metadata.query())
         step_1.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference='steps.0.produce')
         step_1.add_output('produce')
         pipeline.add_step(step_1)
 
-        # Step 2: Extract Attributes
+        # Extract Attributes
         step_2 = meta_pipeline.PrimitiveStep(primitive_description = ExtractColumnsBySemanticTypesPrimitive.metadata.query())
         step_2.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference='steps.1.produce')
         step_2.add_output('produce')
         step_2.add_hyperparameter(name='semantic_types', argument_type=ArgumentType.VALUE, data=['https://metadata.datadrivendiscovery.org/types/Attribute'] )
-        step_2.add_hyperparameter(name='exclude_columns', argument_type=ArgumentType.VALUE, data=[0, 1, 6, 7] )
+        step_2.add_hyperparameter(name='exclude_columns', argument_type=ArgumentType.VALUE, data=[0, 1, 6, 7])
         pipeline.add_step(step_2)
 
-        # Step 3 impute missing data and nans
+        # Impute missing data and nans
         step_3 = meta_pipeline.PrimitiveStep(primitive_description = SKImputer.metadata.query())
         step_3.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference='steps.2.produce')
         step_3.add_output('produce')
@@ -62,76 +61,46 @@ class GRASTAAutoMPGPipeline(BasePipeline):
         step_3.add_hyperparameter(name='return_result', argument_type=ArgumentType.VALUE, data='replace')
         pipeline.add_step(step_3)
 
-        # Step 4: Extract Targets
+        # Extract Targets
         step_4 = meta_pipeline.PrimitiveStep(primitive_description = ExtractColumnsBySemanticTypesPrimitive.metadata.query())
         step_4.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference='steps.1.produce')
         step_4.add_output('produce')
         step_4.add_hyperparameter(name='semantic_types', argument_type=ArgumentType.VALUE, data=['https://metadata.datadrivendiscovery.org/types/TrueTarget'] )
         pipeline.add_step(step_4)
 
-        #Transform attributes dataframe into an ndarray
-        step_5 = meta_pipeline.PrimitiveStep(primitive_description = DataFrameToNDArrayPrimitive.metadata.query())
-        step_5.add_argument(
-            name = 'inputs',
-            argument_type = ArgumentType.CONTAINER,
-            data_reference = 'steps.3.produce' #inputs here are the outputs from step 3
-        )
+        # Transform attributes dataframe into an ndarray
+        step_5 = meta_pipeline.PrimitiveStep(primitive_description=DataFrameToNDArrayPrimitive.metadata.query())
+        step_5.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference='steps.3.produce')
         step_5.add_output('produce')
         pipeline.add_step(step_5)
 
-        #Run GRASTA
+        # Run GRASTA
         step_6 = meta_pipeline.PrimitiveStep(primitive_description = GRASTA.metadata.query())
-        step_6.add_argument(
-            name = 'inputs',
-            argument_type = ArgumentType.CONTAINER,
-            data_reference = 'steps.5.produce' #inputs here are the outputs from step 5
-        )
+        step_6.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference='steps.5.produce')
         step_6.add_output('produce')
         pipeline.add_step(step_6)
         
-        # convert numpy-formatted attribute data to a dataframe
+        # Convert numpy-formatted attribute data to a dataframe
         step_7 = meta_pipeline.PrimitiveStep(primitive_description=NDArrayToDataFramePrimitive.metadata.query())
-        step_7.add_argument(
-            name='inputs',
-            argument_type=ArgumentType.CONTAINER,
-            data_reference='steps.6.produce'  # inputs here are the outputs from step 6
-        )
+        step_7.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference='steps.6.produce')
         step_7.add_output('produce')
         pipeline.add_step(step_7)
 
-        #Linear Regression on low-rank data (inputs and outputs for sklearns are both dataframes)
-        step_8 = meta_pipeline.PrimitiveStep(primitive_description = SKLinearSVR.metadata.query())
-        step_8.add_argument(
-        	name = 'inputs',
-        	argument_type = ArgumentType.CONTAINER,
-        	data_reference = 'steps.7.produce'
-        )
-        step_8.add_argument(
-            name = 'outputs',
-            argument_type = ArgumentType.CONTAINER,
-            data_reference = 'steps.4.produce'
-        )
+        # Linear Regression on low-rank data (inputs and outputs for sklearns are both dataframes)
+        step_8 = meta_pipeline.PrimitiveStep(primitive_description=SKLinearSVR.metadata.query())
+        step_8.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference='steps.7.produce')
+        step_8.add_argument(name='outputs', argument_type=ArgumentType.CONTAINER, data_reference='steps.4.produce')
         step_8.add_output('produce')
         pipeline.add_step(step_8)
 
-        #finally generate a properly-formatted output dataframe from the prediction outputs using the input dataframe as a reference
+        # Finally generate a properly-formatted output dataframe from the prediction outputs using the input dataframe as a reference
         step_9 = meta_pipeline.PrimitiveStep(primitive_description=ConstructPredictionsPrimitive.metadata.query())
-        step_9.add_argument(
-            name='inputs',
-            argument_type=ArgumentType.CONTAINER,
-            data_reference='steps.8.produce'  # inputs here are the prediction column
-        )
-        step_9.add_argument(
-            name='reference',
-            argument_type=ArgumentType.CONTAINER,
-            data_reference='steps.0.produce'  # inputs here are the dataframed input dataset
-        )
+        step_9.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference='steps.8.produce')
+        step_9.add_argument(name='reference', argument_type=ArgumentType.CONTAINER, data_reference='steps.0.produce')
         step_9.add_output('produce')
         pipeline.add_step(step_9)
 
         # Adding output step to the pipeline
-        pipeline.add_output(
-            name='output', 
-            data_reference='steps.9.produce')
+        pipeline.add_output(name='output', data_reference='steps.9.produce')
 
         return pipeline

--- a/spider/pipelines/GRASTAAutoPricePipeline.py
+++ b/spider/pipelines/GRASTAAutoPricePipeline.py
@@ -5,11 +5,11 @@ from spider.pipelines.base import BasePipeline
 from spider.unsupervised_learning.grasta import GRASTA
 from d3m.primitives.data_transformation.dataframe_to_ndarray import Common as DataFrameToNDArrayPrimitive
 from d3m.primitives.data_transformation.ndarray_to_dataframe import Common as NDArrayToDataFramePrimitive
-from d3m.primitives.data_transformation.construct_predictions import Common as ConstructPredictionsPrimitive
 from d3m.primitives.data_transformation.dataset_to_dataframe import Common as DatasetToDataFramePrimitive
 from d3m.primitives.data_transformation.column_parser import Common as ColumnParserPrimitive
 from d3m.primitives.data_transformation.construct_predictions import Common as ConstructPredictionsPrimitive
 from d3m.primitives.data_transformation.extract_columns_by_semantic_types import Common as ExtractColumnsBySemanticTypesPrimitive
+from d3m.primitives.schema_discovery.profiler import Common as SimpleProfilerPrimitive
 from sklearn_wrap.SKLinearSVR import SKLinearSVR
 from sklearn_wrap.SKImputer import SKImputer
 
@@ -34,105 +34,80 @@ class GRASTAAutoPricePipeline(BasePipeline):
         #define inputs.  This will be read in automatically as a Dataset object.
         pipeline.add_input(name = 'inputs')
 
-        # Step 0: DatasetToDataFrame
+        # DatasetToDataFrame
         step_0 = meta_pipeline.PrimitiveStep(primitive_description = DatasetToDataFramePrimitive.metadata.query())
         step_0.add_argument(name='inputs', argument_type = ArgumentType.CONTAINER, data_reference='inputs.0')
         step_0.add_output('produce')
         pipeline.add_step(step_0)
 
-        # Step 1: ColumnParser
-        step_1 = meta_pipeline.PrimitiveStep(primitive_description=ColumnParserPrimitive.metadata.query())
+        # Profiler to infer semantic types
+        step_1 = meta_pipeline.PrimitiveStep(primitive_description=SimpleProfilerPrimitive.metadata.query())
         step_1.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference='steps.0.produce')
         step_1.add_output('produce')
         pipeline.add_step(step_1)
 
-        # Step 2: Extract Attributes
-        step_2 = meta_pipeline.PrimitiveStep(primitive_description = ExtractColumnsBySemanticTypesPrimitive.metadata.query())
+        # ColumnParser
+        step_2 = meta_pipeline.PrimitiveStep(primitive_description=ColumnParserPrimitive.metadata.query())
         step_2.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference='steps.1.produce')
         step_2.add_output('produce')
-        step_2.add_hyperparameter(name='semantic_types', argument_type=ArgumentType.VALUE, data=['https://metadata.datadrivendiscovery.org/types/Attribute'] )
-        #step_2.add_hyperparameter(name='exclude_columns', argument_type=ArgumentType.VALUE, data=[0, 1, 6, 7] )
         pipeline.add_step(step_2)
 
-        # Step 3 impute missing data and nans
-        step_3 = meta_pipeline.PrimitiveStep(primitive_description = SKImputer.metadata.query())
+        # Extract Attributes
+        step_3 = meta_pipeline.PrimitiveStep(primitive_description = ExtractColumnsBySemanticTypesPrimitive.metadata.query())
         step_3.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference='steps.2.produce')
         step_3.add_output('produce')
-        step_3.add_hyperparameter(name='use_semantic_types', argument_type=ArgumentType.VALUE, data=True)
-        step_3.add_hyperparameter(name='return_result', argument_type=ArgumentType.VALUE, data='replace')
+        step_3.add_hyperparameter(name='semantic_types', argument_type=ArgumentType.VALUE, data=['https://metadata.datadrivendiscovery.org/types/Attribute'] )
         pipeline.add_step(step_3)
 
-        # Step 4: Extract Targets
-        step_4 = meta_pipeline.PrimitiveStep(primitive_description = ExtractColumnsBySemanticTypesPrimitive.metadata.query())
-        step_4.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference='steps.1.produce')
+        # Impute missing data and nans
+        step_4 = meta_pipeline.PrimitiveStep(primitive_description = SKImputer.metadata.query())
+        step_4.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference='steps.3.produce')
         step_4.add_output('produce')
-        step_4.add_hyperparameter(name='semantic_types', argument_type=ArgumentType.VALUE, data=['https://metadata.datadrivendiscovery.org/types/TrueTarget'] )
+        step_4.add_hyperparameter(name='use_semantic_types', argument_type=ArgumentType.VALUE, data=True)
+        step_4.add_hyperparameter(name='return_result', argument_type=ArgumentType.VALUE, data='replace')
         pipeline.add_step(step_4)
 
-        #Transform attributes dataframe into an ndarray
-        step_5 = meta_pipeline.PrimitiveStep(primitive_description = DataFrameToNDArrayPrimitive.metadata.query())
-        step_5.add_argument(
-            name = 'inputs',
-            argument_type = ArgumentType.CONTAINER,
-            data_reference = 'steps.3.produce' #inputs here are the outputs from step 3
-        )
+        # Extract Targets
+        step_5 = meta_pipeline.PrimitiveStep(primitive_description = ExtractColumnsBySemanticTypesPrimitive.metadata.query())
+        step_5.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference='steps.2.produce')
         step_5.add_output('produce')
+        step_5.add_hyperparameter(name='semantic_types', argument_type=ArgumentType.VALUE, data=['https://metadata.datadrivendiscovery.org/types/TrueTarget'] )
         pipeline.add_step(step_5)
 
-        #Run GRASTA
-        step_6 = meta_pipeline.PrimitiveStep(primitive_description = GRASTA.metadata.query())
-        step_6.add_argument(
-            name = 'inputs',
-            argument_type = ArgumentType.CONTAINER,
-            data_reference = 'steps.5.produce' #inputs here are the outputs from step 5
-        )
-        step_6.add_hyperparameter(name='constant_step', argument_type=ArgumentType.VALUE, data=0.1)
+        # Transform attributes dataframe into an ndarray
+        step_6 = meta_pipeline.PrimitiveStep(primitive_description=DataFrameToNDArrayPrimitive.metadata.query())
+        step_6.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference='steps.4.produce')
         step_6.add_output('produce')
         pipeline.add_step(step_6)
-        
-        # convert numpy-formatted attribute data to a dataframe
-        step_7 = meta_pipeline.PrimitiveStep(primitive_description=NDArrayToDataFramePrimitive.metadata.query())
-        step_7.add_argument(
-            name='inputs',
-            argument_type=ArgumentType.CONTAINER,
-            data_reference='steps.6.produce'  # inputs here are the outputs from step 6
-        )
+
+        # Run GRASTA
+        step_7 = meta_pipeline.PrimitiveStep(primitive_description = GRASTA.metadata.query())
+        step_7.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference='steps.6.produce')
+        step_7.add_hyperparameter(name='constant_step', argument_type=ArgumentType.VALUE, data=0.1)
         step_7.add_output('produce')
         pipeline.add_step(step_7)
 
-        #Linear Regression on low-rank data (inputs and outputs for sklearns are both dataframes)
-        step_8 = meta_pipeline.PrimitiveStep(primitive_description = SKLinearSVR.metadata.query())
-        step_8.add_argument(
-        	name = 'inputs',
-        	argument_type = ArgumentType.CONTAINER,
-        	data_reference = 'steps.7.produce'
-        )
-        step_8.add_argument(
-            name = 'outputs',
-            argument_type = ArgumentType.CONTAINER,
-            data_reference = 'steps.4.produce'
-        )
+        # Convert numpy-formatted attribute data to a dataframe
+        step_8 = meta_pipeline.PrimitiveStep(primitive_description=NDArrayToDataFramePrimitive.metadata.query())
+        step_8.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference='steps.7.produce')
         step_8.add_output('produce')
         pipeline.add_step(step_8)
 
-        #finally generate a properly-formatted output dataframe from the prediction outputs using the input dataframe as a reference
-        step_9 = meta_pipeline.PrimitiveStep(primitive_description=ConstructPredictionsPrimitive.metadata.query())
-        step_9.add_argument(
-            name='inputs',
-            argument_type=ArgumentType.CONTAINER,
-            data_reference='steps.8.produce'  # inputs here are the prediction column
-        )
-        step_9.add_argument(
-            name='reference',
-            argument_type=ArgumentType.CONTAINER,
-            data_reference='steps.0.produce'  # inputs here are the dataframed input dataset
-        )
+        # Linear Regression on low-rank data (inputs and outputs for sklearns are both dataframes)
+        step_9 = meta_pipeline.PrimitiveStep(primitive_description=SKLinearSVR.metadata.query())
+        step_9.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference='steps.8.produce')
+        step_9.add_argument(name='outputs', argument_type=ArgumentType.CONTAINER, data_reference='steps.5.produce')
         step_9.add_output('produce')
         pipeline.add_step(step_9)
 
+        # Finally generate a properly-formatted output dataframe from the prediction outputs using the input dataframe as a reference
+        step_10 = meta_pipeline.PrimitiveStep(primitive_description=ConstructPredictionsPrimitive.metadata.query())
+        step_10.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference='steps.9.produce')
+        step_10.add_argument(name='reference', argument_type=ArgumentType.CONTAINER, data_reference='steps.0.produce')
+        step_10.add_output('produce')
+        pipeline.add_step(step_10)
+
         # Adding output step to the pipeline
-        pipeline.add_output(
-            name='output', 
-            data_reference='steps.9.produce')
+        pipeline.add_output(name='output', data_reference='steps.10.produce')
 
         return pipeline

--- a/spider/pipelines/GRASTAAutoPricePipeline.py
+++ b/spider/pipelines/GRASTAAutoPricePipeline.py
@@ -22,8 +22,7 @@ class GRASTAAutoPricePipeline(BasePipeline):
         super().__init__()
         
         #specify one seed dataset on which this pipeline can operate
-        self.dataset = 'LL0_207_autoPrice'
-        self.meta_info = self.genmeta(self.dataset)
+        self.dataset = 'LL0_207_autoPrice_MIN_METADATA'
 
     def get_primitive_entry_point(self):
         return 'd3m.primitives.data_compression.grasta.Umich'

--- a/spider/pipelines/GROUSEAutoMPGPipeline.py
+++ b/spider/pipelines/GROUSEAutoMPGPipeline.py
@@ -22,7 +22,6 @@ class GROUSEAutoMPGPipeline(BasePipeline):
         
         #specify one seed dataset on which this pipeline can operate
         self.dataset = '196_autoMpg'
-        self.meta_info = self.genmeta(self.dataset)
 
     def get_primitive_entry_point(self):
         return 'd3m.primitives.data_compression.grouse.Umich'

--- a/spider/pipelines/I3DHMDBActionRecognitionPipeline.py
+++ b/spider/pipelines/I3DHMDBActionRecognitionPipeline.py
@@ -18,7 +18,6 @@ class I3DHMDBActionRecognitionPipeline(BasePipeline):
         super().__init__()
 
         self.dataset = 'LL1_3476_HMDB_actio_recognition'
-        self.meta_info = self.genmeta(self.dataset)
 
     def _gen_pipeline(self):
         #Creating pipeline

--- a/spider/pipelines/KSSOneHundredPlantsMarginPipeline.py
+++ b/spider/pipelines/KSSOneHundredPlantsMarginPipeline.py
@@ -23,7 +23,6 @@ class KSSOneHundredPlantsMarginPipeline(BasePipeline):
         
         #choose one or more seed datasets on which this pipeline can operate
         self.dataset = '1491_one_hundred_plants_margin'
-        self.meta_info = self.genmeta(self.dataset)
 
     def get_primitive_entry_point(self):
         return 'd3m.primitives.clustering.kss.Umich'

--- a/spider/pipelines/OWLRegressionAutoPricePipeline.py
+++ b/spider/pipelines/OWLRegressionAutoPricePipeline.py
@@ -18,8 +18,7 @@ class OWLRegressionAutoPricePipeline(BasePipeline):
         super().__init__()
 
         #specify one seed dataset on which this pipeline can operate
-        self.dataset = 'LL0_207_autoPrice'
-        self.meta_info = self.genmeta(self.dataset)
+        self.dataset = 'LL0_207_autoPrice_MIN_METADATA'
 
     def get_primitive_entry_point(self):
         return 'd3m.primitives.regression.owl_regression.Umich'

--- a/spider/pipelines/OWLRegressionAutoPricePipeline.py
+++ b/spider/pipelines/OWLRegressionAutoPricePipeline.py
@@ -1,5 +1,5 @@
 from d3m.metadata import pipeline as meta_pipeline
-from d3m.metadata.base import ArgumentType, Context
+from d3m.metadata.base import ArgumentType
 
 from spider.pipelines.base import BasePipeline
 from spider.supervised_learning.owl import OWLRegression
@@ -10,7 +10,6 @@ from d3m.primitives.data_transformation.column_parser import Common as ColumnPar
 from d3m.primitives.data_transformation.construct_predictions import Common as ConstructPredictionsPrimitive
 from d3m.primitives.data_transformation.extract_columns_by_semantic_types import Common as ExtractColumnsBySemanticTypesPrimitive
 from sklearn_wrap.SKImputer import SKImputer
-
 
 
 class OWLRegressionAutoPricePipeline(BasePipeline):
@@ -28,50 +27,35 @@ class OWLRegressionAutoPricePipeline(BasePipeline):
         #pipeline context is just metadata, ignore for now
         pipeline = meta_pipeline.Pipeline()
         #define inputs.  This will be read in automatically as a Dataset object.
-        pipeline.add_input(name = 'inputs')
+        pipeline.add_input(name='inputs')
 
-        #step 0: Dataset -> Dataframe
-        step_0 = meta_pipeline.PrimitiveStep(primitive_description = DatasetToDataFramePrimitive.metadata.query())
-        step_0.add_argument(
-                name = 'inputs',
-                argument_type = ArgumentType.CONTAINER,
-                data_reference = 'inputs.0')
+        # Dataset -> Dataframe
+        step_0 = meta_pipeline.PrimitiveStep(primitive_description=DatasetToDataFramePrimitive.metadata.query())
+        step_0.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference='inputs.0')
         step_0.add_output('produce')
         pipeline.add_step(step_0)
 
-        #step 1: ColumnParser
+        # ColumnParser
         step_1 = meta_pipeline.PrimitiveStep(primitive_description=ColumnParserPrimitive.metadata.query())
-        step_1.add_argument(
-                name='inputs',
-                argument_type=ArgumentType.CONTAINER,
-                data_reference='steps.0.produce')
+        step_1.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference='steps.0.produce')
         step_1.add_output('produce')
         pipeline.add_step(step_1)
         
-        #step 2: Extract attributes from dataset into a dedicated dataframe
+        # Extract attributes from dataset into a dedicated dataframe
         step_2 = meta_pipeline.PrimitiveStep(primitive_description = ExtractColumnsBySemanticTypesPrimitive.metadata.query())
-        step_2.add_argument(
-                name = 'inputs',
-                argument_type = ArgumentType.CONTAINER,
-                data_reference = 'steps.1.produce')
+        step_2.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference='steps.1.produce')
         step_2.add_output('produce')
-        step_2.add_hyperparameter(
-                name='semantic_types',
-                argument_type=ArgumentType.VALUE,
-                data=['https://metadata.datadrivendiscovery.org/types/Attribute'])
+        step_2.add_hyperparameter(name='semantic_types', argument_type=ArgumentType.VALUE, data=['https://metadata.datadrivendiscovery.org/types/Attribute'])
         pipeline.add_step(step_2)
 
-        #step 3: Extract Targets
+        # Extract Targets
         step_3 = meta_pipeline.PrimitiveStep(primitive_description = ExtractColumnsBySemanticTypesPrimitive.metadata.query())
         step_3.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference='steps.1.produce')
         step_3.add_output('produce')
-        step_3.add_hyperparameter(
-                name='semantic_types',
-                argument_type=ArgumentType.VALUE,
-                data=['https://metadata.datadrivendiscovery.org/types/TrueTarget'])
+        step_3.add_hyperparameter(name='semantic_types', argument_type=ArgumentType.VALUE, data=['https://metadata.datadrivendiscovery.org/types/TrueTarget'])
         pipeline.add_step(step_3)
         
-        # Step 4 impute missing data and nans
+        # Impute missing data and nans
         step_4 = meta_pipeline.PrimitiveStep(primitive_description = SKImputer.metadata.query())
         step_4.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference='steps.2.produce')
         step_4.add_output('produce')
@@ -79,98 +63,46 @@ class OWLRegressionAutoPricePipeline(BasePipeline):
         step_4.add_hyperparameter(name='return_result', argument_type=ArgumentType.VALUE, data='replace')
         pipeline.add_step(step_4)
 
-        #step 4: transform attributes dataframe into an ndarray
-        step_5 = meta_pipeline.PrimitiveStep(primitive_description = DataFrameToNDArrayPrimitive.metadata.query())
-        step_5.add_argument(
-                name = 'inputs',
-                argument_type = ArgumentType.CONTAINER,
-                data_reference = 'steps.4.produce'
-        )
+        # Transform attributes dataframe into an ndarray
+        step_5 = meta_pipeline.PrimitiveStep(primitive_description=DataFrameToNDArrayPrimitive.metadata.query())
+        step_5.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference='steps.4.produce')
         step_5.add_output('produce')
         pipeline.add_step(step_5)
 
-        #step 6: transform targets dataframe into an ndarray
-        step_6 = meta_pipeline.PrimitiveStep(primitive_description = DataFrameToNDArrayPrimitive.metadata.query())
-        step_6.add_argument(
-                name = 'inputs',
-                argument_type = ArgumentType.CONTAINER,
-                data_reference = 'steps.3.produce'
-        )
+        # Transform targets dataframe into an ndarray
+        step_6 = meta_pipeline.PrimitiveStep(primitive_description=DataFrameToNDArrayPrimitive.metadata.query())
+        step_6.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference='steps.3.produce')
         step_6.add_output('produce')
         pipeline.add_step(step_6)
         
-        attributes = 'steps.5.produce'
-        targets    = 'steps.6.produce'
-
-        #step 7: OWLRegression
+        # OWLRegression
         step_7 = meta_pipeline.PrimitiveStep(primitive_description=OWLRegression.metadata.query())
-        step_7.add_hyperparameter(
-                name='normalize',
-                argument_type=ArgumentType.VALUE,
-                data=True)
-        step_7.add_hyperparameter(
-                name='learning_rate',
-                argument_type=ArgumentType.VALUE,
-                data=2e-1)
-        step_7.add_hyperparameter(
-                name='tol',
-                argument_type=ArgumentType.VALUE,
-                data=1e-3)
-        step_7.add_hyperparameter(
-                name='weight_max_val',
-                argument_type=ArgumentType.VALUE,
-                data=175)
-        step_7.add_hyperparameter(
-                name='weight_max_off',
-                argument_type=ArgumentType.VALUE,
-                data=0)
-        step_7.add_hyperparameter(
-                name='weight_min_val',
-                argument_type=ArgumentType.VALUE,
-                data=0)
-        step_7.add_hyperparameter(
-                name='weight_min_off',
-                argument_type=ArgumentType.VALUE,
-                data=13)
-        step_7.add_argument(
-                name='inputs',
-                argument_type=ArgumentType.CONTAINER,
-                data_reference=attributes)
-        step_7.add_argument(
-                name='outputs',
-                argument_type=ArgumentType.CONTAINER,
-                data_reference=targets)
+        step_7.add_hyperparameter(name='normalize', argument_type=ArgumentType.VALUE, data=True)
+        step_7.add_hyperparameter(name='learning_rate', argument_type=ArgumentType.VALUE, data=2e-1)
+        step_7.add_hyperparameter(name='tol', argument_type=ArgumentType.VALUE, data=1e-3)
+        step_7.add_hyperparameter(name='weight_max_val', argument_type=ArgumentType.VALUE, data=175)
+        step_7.add_hyperparameter(name='weight_max_off', argument_type=ArgumentType.VALUE, data=0)
+        step_7.add_hyperparameter(name='weight_min_val', argument_type=ArgumentType.VALUE, data=0)
+        step_7.add_hyperparameter(name='weight_min_off', argument_type=ArgumentType.VALUE, data=13)
+        step_7.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference='steps.5.produce')
+        step_7.add_argument(name='outputs', argument_type=ArgumentType.CONTAINER, data_reference='steps.6.produce')
         step_7.add_output('produce')
         pipeline.add_step(step_7)
 
-        #step 8: convert numpy-formatted prediction outputs to a dataframe
-        step_8 = meta_pipeline.PrimitiveStep(primitive_description = NDArrayToDataFramePrimitive.metadata.query())
-        step_8.add_argument(
-                name = 'inputs',
-                argument_type = ArgumentType.CONTAINER,
-                data_reference = 'steps.7.produce'
-        )
+        # Convert numpy-formatted prediction outputs to a dataframe
+        step_8 = meta_pipeline.PrimitiveStep(primitive_description=NDArrayToDataFramePrimitive.metadata.query())
+        step_8.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference='steps.7.produce')
         step_8.add_output('produce')
         pipeline.add_step(step_8)
 
-        #step 9: generate a properly-formatted output dataframe from the dataframed prediction outputs using the input dataframe as a reference
-        step_9 = meta_pipeline.PrimitiveStep(primitive_description = ConstructPredictionsPrimitive.metadata.query())
-        step_9.add_argument(
-                name = 'inputs',
-                argument_type = ArgumentType.CONTAINER,
-                data_reference = 'steps.8.produce' #inputs here are the prediction column
-        )
-        step_9.add_argument(
-                name = 'reference',
-                argument_type = ArgumentType.CONTAINER,
-                data_reference = 'steps.0.produce' #inputs here are the dataframed input dataset
-        )
+        # Generate a properly-formatted output dataframe from the dataframed prediction outputs using the input dataframe as a reference
+        step_9 = meta_pipeline.PrimitiveStep(primitive_description=ConstructPredictionsPrimitive.metadata.query())
+        step_9.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference='steps.8.produce')
+        step_9.add_argument(name='reference', argument_type=ArgumentType.CONTAINER, data_reference='steps.0.produce')
         step_9.add_output('produce')
         pipeline.add_step(step_9)
 
         # Final Output
-        pipeline.add_output(
-                name='output',
-                data_reference='steps.9.produce')
+        pipeline.add_output(name='output', data_reference='steps.9.produce')
 
         return pipeline

--- a/spider/pipelines/OWLRegressionAutoPricePipeline.py
+++ b/spider/pipelines/OWLRegressionAutoPricePipeline.py
@@ -9,6 +9,7 @@ from d3m.primitives.data_transformation.dataset_to_dataframe import Common as Da
 from d3m.primitives.data_transformation.column_parser import Common as ColumnParserPrimitive
 from d3m.primitives.data_transformation.construct_predictions import Common as ConstructPredictionsPrimitive
 from d3m.primitives.data_transformation.extract_columns_by_semantic_types import Common as ExtractColumnsBySemanticTypesPrimitive
+from d3m.primitives.schema_discovery.profiler import Common as SimpleProfilerPrimitive
 from sklearn_wrap.SKImputer import SKImputer
 
 
@@ -35,74 +36,80 @@ class OWLRegressionAutoPricePipeline(BasePipeline):
         step_0.add_output('produce')
         pipeline.add_step(step_0)
 
-        # ColumnParser
-        step_1 = meta_pipeline.PrimitiveStep(primitive_description=ColumnParserPrimitive.metadata.query())
+        # Profiler to infer semantic types
+        step_1 = meta_pipeline.PrimitiveStep(primitive_description=SimpleProfilerPrimitive.metadata.query())
         step_1.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference='steps.0.produce')
         step_1.add_output('produce')
         pipeline.add_step(step_1)
-        
-        # Extract attributes from dataset into a dedicated dataframe
-        step_2 = meta_pipeline.PrimitiveStep(primitive_description = ExtractColumnsBySemanticTypesPrimitive.metadata.query())
+
+        # ColumnParser
+        step_2 = meta_pipeline.PrimitiveStep(primitive_description=ColumnParserPrimitive.metadata.query())
         step_2.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference='steps.1.produce')
         step_2.add_output('produce')
-        step_2.add_hyperparameter(name='semantic_types', argument_type=ArgumentType.VALUE, data=['https://metadata.datadrivendiscovery.org/types/Attribute'])
         pipeline.add_step(step_2)
 
-        # Extract Targets
+        # Extract Attributes
         step_3 = meta_pipeline.PrimitiveStep(primitive_description = ExtractColumnsBySemanticTypesPrimitive.metadata.query())
-        step_3.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference='steps.1.produce')
+        step_3.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference='steps.2.produce')
         step_3.add_output('produce')
-        step_3.add_hyperparameter(name='semantic_types', argument_type=ArgumentType.VALUE, data=['https://metadata.datadrivendiscovery.org/types/TrueTarget'])
+        step_3.add_hyperparameter(name='semantic_types', argument_type=ArgumentType.VALUE, data=['https://metadata.datadrivendiscovery.org/types/Attribute'] )
         pipeline.add_step(step_3)
-        
-        # Impute missing data and nans
-        step_4 = meta_pipeline.PrimitiveStep(primitive_description = SKImputer.metadata.query())
+
+        # Extract Targets
+        step_4 = meta_pipeline.PrimitiveStep(primitive_description = ExtractColumnsBySemanticTypesPrimitive.metadata.query())
         step_4.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference='steps.2.produce')
         step_4.add_output('produce')
-        step_4.add_hyperparameter(name='use_semantic_types', argument_type=ArgumentType.VALUE, data=True)
-        step_4.add_hyperparameter(name='return_result', argument_type=ArgumentType.VALUE, data='replace')
+        step_4.add_hyperparameter(name='semantic_types', argument_type=ArgumentType.VALUE, data=['https://metadata.datadrivendiscovery.org/types/TrueTarget'])
         pipeline.add_step(step_4)
-
-        # Transform attributes dataframe into an ndarray
-        step_5 = meta_pipeline.PrimitiveStep(primitive_description=DataFrameToNDArrayPrimitive.metadata.query())
-        step_5.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference='steps.4.produce')
+        
+        # Impute missing data and nans
+        step_5 = meta_pipeline.PrimitiveStep(primitive_description = SKImputer.metadata.query())
+        step_5.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference='steps.3.produce')
         step_5.add_output('produce')
+        step_5.add_hyperparameter(name='use_semantic_types', argument_type=ArgumentType.VALUE, data=True)
+        step_5.add_hyperparameter(name='return_result', argument_type=ArgumentType.VALUE, data='replace')
         pipeline.add_step(step_5)
 
-        # Transform targets dataframe into an ndarray
+        # Transform attributes dataframe into an ndarray
         step_6 = meta_pipeline.PrimitiveStep(primitive_description=DataFrameToNDArrayPrimitive.metadata.query())
-        step_6.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference='steps.3.produce')
+        step_6.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference='steps.5.produce')
         step_6.add_output('produce')
         pipeline.add_step(step_6)
-        
-        # OWLRegression
-        step_7 = meta_pipeline.PrimitiveStep(primitive_description=OWLRegression.metadata.query())
-        step_7.add_hyperparameter(name='normalize', argument_type=ArgumentType.VALUE, data=True)
-        step_7.add_hyperparameter(name='learning_rate', argument_type=ArgumentType.VALUE, data=2e-1)
-        step_7.add_hyperparameter(name='tol', argument_type=ArgumentType.VALUE, data=1e-3)
-        step_7.add_hyperparameter(name='weight_max_val', argument_type=ArgumentType.VALUE, data=175)
-        step_7.add_hyperparameter(name='weight_max_off', argument_type=ArgumentType.VALUE, data=0)
-        step_7.add_hyperparameter(name='weight_min_val', argument_type=ArgumentType.VALUE, data=0)
-        step_7.add_hyperparameter(name='weight_min_off', argument_type=ArgumentType.VALUE, data=13)
-        step_7.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference='steps.5.produce')
-        step_7.add_argument(name='outputs', argument_type=ArgumentType.CONTAINER, data_reference='steps.6.produce')
+
+        # Transform targets dataframe into an ndarray
+        step_7 = meta_pipeline.PrimitiveStep(primitive_description=DataFrameToNDArrayPrimitive.metadata.query())
+        step_7.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference='steps.4.produce')
         step_7.add_output('produce')
         pipeline.add_step(step_7)
-
-        # Convert numpy-formatted prediction outputs to a dataframe
-        step_8 = meta_pipeline.PrimitiveStep(primitive_description=NDArrayToDataFramePrimitive.metadata.query())
-        step_8.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference='steps.7.produce')
+        
+        # OWLRegression
+        step_8 = meta_pipeline.PrimitiveStep(primitive_description=OWLRegression.metadata.query())
+        step_8.add_hyperparameter(name='normalize', argument_type=ArgumentType.VALUE, data=True)
+        step_8.add_hyperparameter(name='learning_rate', argument_type=ArgumentType.VALUE, data=2e-1)
+        step_8.add_hyperparameter(name='tol', argument_type=ArgumentType.VALUE, data=1e-3)
+        step_8.add_hyperparameter(name='weight_max_val', argument_type=ArgumentType.VALUE, data=175)
+        step_8.add_hyperparameter(name='weight_max_off', argument_type=ArgumentType.VALUE, data=0)
+        step_8.add_hyperparameter(name='weight_min_val', argument_type=ArgumentType.VALUE, data=0)
+        step_8.add_hyperparameter(name='weight_min_off', argument_type=ArgumentType.VALUE, data=13)
+        step_8.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference='steps.6.produce')
+        step_8.add_argument(name='outputs', argument_type=ArgumentType.CONTAINER, data_reference='steps.7.produce')
         step_8.add_output('produce')
         pipeline.add_step(step_8)
 
-        # Generate a properly-formatted output dataframe from the dataframed prediction outputs using the input dataframe as a reference
-        step_9 = meta_pipeline.PrimitiveStep(primitive_description=ConstructPredictionsPrimitive.metadata.query())
+        # Convert numpy-formatted prediction outputs to a dataframe
+        step_9 = meta_pipeline.PrimitiveStep(primitive_description=NDArrayToDataFramePrimitive.metadata.query())
         step_9.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference='steps.8.produce')
-        step_9.add_argument(name='reference', argument_type=ArgumentType.CONTAINER, data_reference='steps.0.produce')
         step_9.add_output('produce')
         pipeline.add_step(step_9)
 
+        # Generate a properly-formatted output dataframe from the dataframed prediction outputs using the input dataframe as a reference
+        step_10 = meta_pipeline.PrimitiveStep(primitive_description=ConstructPredictionsPrimitive.metadata.query())
+        step_10.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference='steps.9.produce')
+        step_10.add_argument(name='reference', argument_type=ArgumentType.CONTAINER, data_reference='steps.0.produce')
+        step_10.add_output('produce')
+        pipeline.add_step(step_10)
+
         # Final Output
-        pipeline.add_output(name='output', data_reference='steps.9.produce')
+        pipeline.add_output(name='output', data_reference='steps.10.produce')
 
         return pipeline

--- a/spider/pipelines/PCPIALMHandgeometryPipeline.py
+++ b/spider/pipelines/PCPIALMHandgeometryPipeline.py
@@ -20,7 +20,6 @@ class PCPIALMHandgeometryPipeline(BasePipeline):
         super().__init__()
 
         self.dataset = '22_handgeometry'
-        self.meta_info = self.genmeta(self.dataset)
 
     def get_primitive_entry_point(self):
         return 'd3m.primitives.data_compression.pcp_ialm.Umich'

--- a/spider/pipelines/RPCALBDHandgeometryPipeline.py
+++ b/spider/pipelines/RPCALBDHandgeometryPipeline.py
@@ -20,7 +20,6 @@ class RPCALBDHandgeometryPipeline(BasePipeline):
         super().__init__()
 
         self.dataset = '22_handgeometry'
-        self.meta_info = self.genmeta(self.dataset)
 
     def get_primitive_entry_point(self):
         return 'd3m.primitives.data_compression.rpca_lbd.Umich'

--- a/spider/pipelines/SSCADMMOneHundredPlantsMarginPipeline.py
+++ b/spider/pipelines/SSCADMMOneHundredPlantsMarginPipeline.py
@@ -23,7 +23,6 @@ class SSCADMMOneHundredPlantsMarginPipeline(BasePipeline):
         
         #choose one or more seed datasets on which this pipeline can operate
         self.dataset = '1491_one_hundred_plants_margin'
-        self.meta_info = self.genmeta(self.dataset)
 
     def get_primitive_entry_point(self):
         return 'd3m.primitives.clustering.ssc_admm.Umich'

--- a/spider/pipelines/SSCCVXOneHundredPlantsMarginPipeline.py
+++ b/spider/pipelines/SSCCVXOneHundredPlantsMarginPipeline.py
@@ -23,7 +23,6 @@ class SSCCVXOneHundredPlantsMarginPipeline(BasePipeline):
         
         #choose one or more seed datasets on which this pipeline can operate
         self.dataset = '1491_one_hundred_plants_margin'
-        self.meta_info = self.genmeta(self.dataset)
 
     def get_primitive_entry_point(self):
         return 'd3m.primitives.clustering.ssc_cvx.Umich'

--- a/spider/pipelines/SSCOMPOneHundredPlantsMarginPipeline.py
+++ b/spider/pipelines/SSCOMPOneHundredPlantsMarginPipeline.py
@@ -23,7 +23,6 @@ class SSCOMPOneHundredPlantsMarginPipeline(BasePipeline):
         
         #choose one or more seed datasets on which this pipeline can operate
         self.dataset = '1491_one_hundred_plants_margin'
-        self.meta_info = self.genmeta(self.dataset)
 
     def get_primitive_entry_point(self):
         return 'd3m.primitives.clustering.ssc_omp.Umich'

--- a/spider/pipelines/VGG16HandgeometryPipeline.py
+++ b/spider/pipelines/VGG16HandgeometryPipeline.py
@@ -18,7 +18,6 @@ class VGG16HandgeometryPipeline(BasePipeline):
         super().__init__()
 
         self.dataset = '22_handgeometry'
-        self.meta_info = self.genmeta(self.dataset)
 
     def get_primitive_entry_point(self):
         return 'd3m.primitives.feature_extraction.vgg16.Umich'

--- a/spider/pipelines/base.py
+++ b/spider/pipelines/base.py
@@ -28,15 +28,6 @@ class BasePipeline(object):
     def get_id(self):
         return self._pipeline.id
         
-    def genmeta(self, dataset):
-        meta_info = {
-            'problem': dataset + "_problem",
-            'full_inputs': [ dataset + "_dataset" ],
-            'train_inputs': [ dataset + "_dataset_TRAIN" ],
-            'test_inputs': [ dataset + "_dataset_TEST" ],
-            'score_inputs': [ dataset + "_dataset_SCORE" ]}
-        return meta_info
-
     def get_json(self):
         # Make it pretty.
         return json.dumps(json.loads(self._pipeline.to_json()), indent = 4)
@@ -62,7 +53,7 @@ class BasePipeline(object):
                    ' -r /datasets/seed_datasets_current/{dataset}/{dataset}_problem/problemDoc.json' \
                    ' -i /datasets/seed_datasets_current/{dataset}/TRAIN/dataset_TRAIN/datasetDoc.json' \
                    ' -t /datasets/seed_datasets_current/{dataset}/TEST/dataset_TEST/datasetDoc.json' \
-                   ' -a /datasets/seed_datasets_current/{dataset}/SCORE/dataset_TEST/datasetDoc.json' \
+                   ' -a /datasets/seed_datasets_current/{dataset}/SCORE/dataset_SCORE/datasetDoc.json' \
                    ' -o /dev/null' \
                    ' -O Michigan/{primitive}/0.0.5/pipeline_runs/{pipeline}.yaml' \
                    ' > pipeline_results/{pipeline}.txt'


### PR DESCRIPTION
Pipelines now run on gitlab.datadrivendiscovery.org/d3m/datasets as per #34.

* Added simple profiler step to infer semantic types, since that metadata was removed for the `2020.1.24.min-metadata` tag in gitlab.datadrivendiscovery.org/d3m/datasets.
* Added dataset check in `genjson.py`. This softly enforces version control so we know which version of the dataset repo the pipelines can run on.